### PR TITLE
3671 Ship/API support GoPrint update docs

### DIFF
--- a/ratesqueryv1/POST_createandprint.md
+++ b/ratesqueryv1/POST_createandprint.md
@@ -36,6 +36,8 @@ You need to extend the AvailableRates post body to include other fields specifie
       LABEL_PNG_100X150 - label is presented as a PNG image with dimension 100mm x 150mm  
       LABEL_PDF_100X175 - label is presented as a PDF with dimension 100mm x 175mm  
       LABEL_PDF_100X150 - label is presented as a PDF with dimension 100mm x 150mm  
+      USER_CONFIGURED - label is presented as a PDF when [User's Printing Setting](https://ship.gosweetspot.com/settings) is PDF file, or a PRN file is presented if [User's Printing Setting](https://ship.gosweetspot.com/settings) is GoPrint - PRN Download
+      GOPRINT_PRN - PRN file is presented
 
       The 100x150 sizing is presently experimental and not available across all carriers.  
 

--- a/ratesqueryv1/POST_printcheapestcourier.md
+++ b/ratesqueryv1/POST_printcheapestcourier.md
@@ -31,6 +31,8 @@ Upon creating the shipment, the print command can also be automatically initiate
       LABEL_PNG_100X150 - label is presented as a PNG image with dimension 100mm x 150mm  
       LABEL_PDF_100X175 - label is presented as a PDF with dimension 100mm x 175mm  
       LABEL_PDF_100X150 - label is presented as a PDF with dimension 100mm x 150mm  
+      USER_CONFIGURED - label is presented as a PDF when [User's Printing Setting](https://ship.gosweetspot.com/settings) is PDF file, or a PRN file is presented if [User's Printing Setting](https://ship.gosweetspot.com/settings) is GoPrint - PRN Download
+      GOPRINT_PRN - PRN file is presented
 
       The 100x150 sizing is presently experimental and not available across all carriers.  
 

--- a/shipments/post.md
+++ b/shipments/post.md
@@ -52,6 +52,8 @@ When *QuoteId* is supplied, the *carrier* and *service* fields are ignored.  The
       LABEL_PNG_100X150 - label is presented as a PNG image with dimension 100mm x 150mm  
       LABEL_PDF_100X175 - label is presented as a PDF with dimension 100mm x 175mm  
       LABEL_PDF_100X150 - label is presented as a PDF with dimension 100mm x 150mm  
+      USER_CONFIGURED - label is presented as a PDF when [User's Printing Setting](https://ship.gosweetspot.com/settings) is PDF file, or a PRN file is presented if [User's Printing Setting](https://ship.gosweetspot.com/settings) is GoPrint - PRN Download
+      GOPRINT_PRN - PRN file is presented
 
       The 100x150 sizing is presently experimental and not available across all carriers.  
 - **hasdg** - true/false - does your shipment contain any dangerous goods


### PR DESCRIPTION
Update the docs for Ship/API supporting GoPrint 
/ratesqueryv1/POST_printcheapestcourier
/ratesqueryv1/POST_createandprint
/shipments/post
