### PR TITLE
4489 Add ConsignmentItem.MarkedUp_LineTotal to /api/shipment API response

### DIFF
--- a/shipments/get.md
+++ b/shipments/get.md
@@ -324,6 +324,11 @@ Get status updates for shipments
 						<td>Total charge determined for this item at the time of consignment creation.</td>
                                             </tr>
                                             <tr>
+                                                <td>Charge_MarkedUpLineTotal</td>
+                                                <td>decimal</td>
+						<td>Total charge with mark up (if defined) determined for this item at the time of consignment creation.</td>
+                                            </tr>
+                                            <tr>
                                                 <td>PickedAt</td>
                                                 <td>Nullable DateTime</td>
 						<td>Date and time this item was picked up - will be null if not yet picked up.</td>


### PR DESCRIPTION
Add ConsignmentItem.MarkedUp_LineTotal property for new field in /api/shipment API response.

Note: only includes changes in client for GET /api/shipment response, not POST /api/shipment response, because the latter has no fields for consignment items at all.

# Impacts:
Users: **New and updated API client users** 
Systems: **Ship API client** 

# Merge Considerations:
EDMX Changes? **No**
Are database changes backwards compatible? **N/A**
Are there any schematic changes that could cause blocks? Frequently used tables? **N/A**

# Testing:


# Deployment Steps:
Should be deployed AFTER PR 2765 on Azure DevOps.

**Deployment plan:**

**Risks**
No risk.

**Rollback plan:** 
Will IIS rollback be sufficient? **N/A**
Will DB rollback be sufficient? **N/A**

# Configuration:
Are there any new Feature switches are config settings introduced? **No**
If Yes - does this require devops pipeline, octopus deploy changes? **N/A**
	If Yes - Have the changes been made? **N/A**
