### PR TITLE
#5752 return carrier id for available services

### DIFF
--- a/AvailableServices/Get.md
+++ b/AvailableServices/Get.md
@@ -26,6 +26,7 @@ A JSON Object of available carriers.
 
 #### Carrier
 * AccountNumber - string
+* CarrierId - integer
 * CarrierName - string
 * CarrierType - string
 * Services - Array of strings
@@ -45,14 +46,16 @@ A JSON Object of available carriers.
 {
   "Carriers": [
     {
+      "CarrierId": 779,
       "CarrierName": "FedEx",
-      "CarrierType": "FedEx",
+      "CarrierType": "FedEx",      
       "Services": [
         "All"
       ],
       "AccountNumber": "1234"
     },
     {
+      "CarrierId": 432,
       "CarrierName": "Post Haste",
       "CarrierType": "PostHaste",
       "Services": [
@@ -64,6 +67,7 @@ A JSON Object of available carriers.
     }
     ,
     {
+      "CarrierId": 805,
       "CarrierName": "NZ Post",
       "CarrierType": "NZPost",
       "Services": [
@@ -76,6 +80,7 @@ A JSON Object of available carriers.
       "AccountNumber": "1234"
     },
     {
+      "CarrierId": 205,
       "CarrierName": "Mainstream AKL",
       "CarrierType": "Mainstream",
       "Services": [
@@ -86,6 +91,7 @@ A JSON Object of available carriers.
       "AccountNumber": "1234"
     },
     {
+      "CarrierId": 542,
       "CarrierName": "NZ Couriers",
       "CarrierType": "NZCouriers",
       "Services": [


### PR DESCRIPTION
[User Story 5752](https://gosweetspot.visualstudio.com/GoSweetSpot%20Core/_workitems/edit/5752): Ship API: As integrator I want CarrierId added to api/AvailableServices response so it can matched with api/rates response